### PR TITLE
tmpfs customizable size

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ forgejo_base_path: "/{{ forgejo_identifier }}"
 forgejo_data_dir_path: "{{ forgejo_base_path }}/data"
 forgejo_config_dir_path: "{{ forgejo_base_path }}/config"
 # Default value for the container's tmpfs size
-forgejo_forgejo_container_tmpfs_size: 128m
+forgejo_forgejo_container_tmpfs_size_mb: 128m
 
 # renovate: datasource=docker depName=codeberg.org/forgejo/forgejo versioning=semver
 forgejo_version: 11.0.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ forgejo_identifier: forgejo
 forgejo_base_path: "/{{ forgejo_identifier }}"
 forgejo_data_dir_path: "{{ forgejo_base_path }}/data"
 forgejo_config_dir_path: "{{ forgejo_base_path }}/config"
+# Default value for the container's tmpfs size
+forgejo_forgejo_container_tmpfs_size: 128m
 
 # renovate: datasource=docker depName=codeberg.org/forgejo/forgejo versioning=semver
 forgejo_version: 11.0.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,8 +15,7 @@ forgejo_identifier: forgejo
 forgejo_base_path: "/{{ forgejo_identifier }}"
 forgejo_data_dir_path: "{{ forgejo_base_path }}/data"
 forgejo_config_dir_path: "{{ forgejo_base_path }}/config"
-# Default value for the container's tmpfs size
-forgejo_forgejo_container_tmpfs_size_mb: 128m
+
 
 # renovate: datasource=docker depName=codeberg.org/forgejo/forgejo versioning=semver
 forgejo_version: 11.0.1
@@ -64,6 +63,9 @@ forgejo_container_http_port: 3000
 
 # Controls the `FORGEJO__server__SSH_LISTEN_PORT` environment variable.
 forgejo_container_ssh_port: 2222
+
+# The size of the container's tmpfs volume
+forgejo_forgejo_container_tmpfs_size_mb: 128
 
 # A list of additional container networks that the container would be connected to.
 # The playbook does not create these networks, so make sure they already exist.

--- a/templates/systemd/forgejo.service.j2
+++ b/templates/systemd/forgejo.service.j2
@@ -45,7 +45,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       --label-file={{ forgejo_base_path }}/labels \
       --mount type=bind,src={{ forgejo_data_dir_path }},dst=/var/lib/gitea \
       --mount type=bind,src={{ forgejo_config_dir_path }},dst=/etc/gitea \
-      --tmpfs=/tmp:rw,noexec,nosuid,size=128m \
+      --tmpfs=/tmp:rw,noexec,nosuid,size={{ forgejo_container_tmpfs_size  | default('128m') }} \
       {{ forgejo_container_image_self_build_name if forgejo_container_image_self_build else forgejo_container_image }}
 
 {% for network in forgejo_container_additional_networks %}

--- a/templates/systemd/forgejo.service.j2
+++ b/templates/systemd/forgejo.service.j2
@@ -45,7 +45,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       --label-file={{ forgejo_base_path }}/labels \
       --mount type=bind,src={{ forgejo_data_dir_path }},dst=/var/lib/gitea \
       --mount type=bind,src={{ forgejo_config_dir_path }},dst=/etc/gitea \
-      --tmpfs=/tmp:rw,noexec,nosuid,size={{ forgejo_container_tmpfs_size  | default('128m') }} \
+      --tmpfs=/tmp:rw,noexec,nosuid,size={{ forgejo_container_tmpfs_size_mb }}m \
       {{ forgejo_container_image_self_build_name if forgejo_container_image_self_build else forgejo_container_image }}
 
 {% for network in forgejo_container_additional_networks %}


### PR DESCRIPTION
Fix: Increase tmpfs size for Forgejo container to support large repos

This PR addresses the "message authentication code incorrect" error experienced during git pull operations on large repositories.

The issue was caused by the Forgejo container running out of temporary disk space in its `/tmp` directory (which defaults to 128MB) when processing large Git packfiles during pulls.

This change increases the `tmpfs` size for `/tmp` to specified size by modifying the systemd service template that launches the Forgejo Docker container. This provides sufficient temporary space for Git's internal operations, resolving the issue.

A new Ansible variable, 'forgejo_container_tmpfs_size', has been introduced to allow easy configuration of this value.